### PR TITLE
Fix some crashes and support all chars (hopefully)

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -147,7 +147,7 @@ fn get_os_input<OsInputOutput>(
         Err(e) => {
             eprintln!("failed to open terminal:\n{:?}", e);
             process::exit(1);
-        }
+        },
     }
 }
 

--- a/src/sessions.rs
+++ b/src/sessions.rs
@@ -168,7 +168,8 @@ fn assert_socket(name: &str) -> bool {
         Ok(stream) => {
             let mut receiver = IpcReceiverWithContext::new(stream);
             let mut sender = receiver.get_sender();
-            sender.send(ClientToServerMsg::ConnStatus)
+            sender
+                .send(ClientToServerMsg::ConnStatus)
                 .with_context(|| "Query connection status")
                 .non_fatal();
             let _ = sender.send(ClientToServerMsg::ConnStatus);

--- a/zellij-server/src/route.rs
+++ b/zellij-server/src/route.rs
@@ -890,9 +890,9 @@ pub(crate) fn route_thread_main(
                                         ))
                                     })
                                     .and_then(|min_size| {
-                                        rlocked_sessions
-                                            .senders
-                                            .send_to_screen(ScreenInstruction::TerminalResize(min_size))
+                                        rlocked_sessions.senders.send_to_screen(
+                                            ScreenInstruction::TerminalResize(min_size),
+                                        )
                                     })
                                     .with_context(err_context)?;
                             }
@@ -1011,9 +1011,7 @@ pub(crate) fn route_thread_main(
                 }
             },
             None => {
-                log::error!(
-                    "Error receiving Message from client, logging client out."
-                );
+                log::error!("Error receiving Message from client, logging client out.");
                 let _ = os_input.send_to_client(
                     client_id,
                     ServerToClientMsg::Exit(ExitReason::Error(

--- a/zellij-utils/src/consts.rs
+++ b/zellij-utils/src/consts.rs
@@ -155,11 +155,11 @@ pub use windows_only::*;
 #[cfg(windows)]
 mod windows_only {
     use super::*;
-    use std::{path::PathBuf, fs, env::temp_dir};
+    use std::{env::temp_dir, fs, path::PathBuf};
 
     use lazy_static::lazy_static;
 
-    use crate::{shared::set_permissions, envs};
+    use crate::{envs, shared::set_permissions};
 
     fn get_username() -> String {
         use std::ptr;
@@ -196,7 +196,8 @@ mod windows_only {
             sock_dir.push(envs::get_session_name().unwrap());
             sock_dir
         };
-        pub static ref ZELLIJ_TMP_DIR: PathBuf = temp_dir().join(format!("zellij-{}", USERNAME.as_str()));
+        pub static ref ZELLIJ_TMP_DIR: PathBuf =
+            temp_dir().join(format!("zellij-{}", USERNAME.as_str()));
         pub static ref ZELLIJ_TMP_LOG_DIR: PathBuf = ZELLIJ_TMP_DIR.join("zellij-log");
         pub static ref ZELLIJ_TMP_LOG_FILE: PathBuf = ZELLIJ_TMP_LOG_DIR.join("zellij.log");
         pub static ref ZELLIJ_SOCK_DIR: PathBuf = {

--- a/zellij-utils/src/input/layout.rs
+++ b/zellij-utils/src/input/layout.rs
@@ -883,7 +883,7 @@ impl Layout {
             None => {
                 let home = find_default_config_dir();
                 let Some(home) = home else {
-                    return Layout::stringified_from_default_assets(layout)
+                    return Layout::stringified_from_default_assets(layout);
                 };
 
                 let layout_path = &home.join(layout);

--- a/zellij-utils/src/input/options.rs
+++ b/zellij-utils/src/input/options.rs
@@ -1,7 +1,7 @@
 //! Handles cli and configuration options
 use crate::cli::Command;
 use crate::data::InputMode;
-use clap::{ValueEnum, Args};
+use clap::{Args, ValueEnum};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use std::str::FromStr;

--- a/zellij-utils/src/windows_utils/named_pipe.rs
+++ b/zellij-utils/src/windows_utils/named_pipe.rs
@@ -61,7 +61,9 @@ struct EventedOverlapped(OVERLAPPED);
 impl Drop for EventedOverlapped {
     fn drop(&mut self) {
         if (!self.0.hEvent.is_null()) {
-            unsafe { CloseHandle(self.0.hEvent); }
+            unsafe {
+                CloseHandle(self.0.hEvent);
+            }
         }
     }
 }
@@ -233,7 +235,7 @@ impl PipeStream {
         .map(|_| Self::from(dup_handle))
     }
 
-    pub fn connect(path: impl AsRef<OsStr>)  -> io::Result<Self> {
+    pub fn connect(path: impl AsRef<OsStr>) -> io::Result<Self> {
         Pipe::new(path).connect()
     }
 }

--- a/zellij-utils/src/windows_utils/named_pipe.rs
+++ b/zellij-utils/src/windows_utils/named_pipe.rs
@@ -238,12 +238,6 @@ impl PipeStream {
     }
 }
 
-impl IntoRawHandle for PipeStream {
-    fn into_raw_handle(self) -> std::os::windows::prelude::RawHandle {
-        self.0.into_raw_handle()
-    }
-}
-
 impl From<HANDLE> for PipeStream {
     fn from(value: HANDLE) -> Self {
         let handle = unsafe { OwnedHandle::from_raw_handle(value as _) };


### PR DESCRIPTION
After months of frustration I finally realized
we just need to tell windows we are speaking UTF8.

And we allow Characters now even if a controlkey is pressed.
Yes windows sends multiple KeyEvents for a single multibyte codepoint (debugged with € U+20AC).

This should make zellij on windows more reliable and fix the issues reported with some keys not working.

The test version I installed on my work computer reliably deadlocks when I enter one of (`ä`,`ü`,`ö`,`ß`), so I need to install this for testing there.