### PR TITLE
Fix(mouse) windows panic during mouse dragging

### DIFF
--- a/zellij-client/Cargo.toml
+++ b/zellij-client/Cargo.toml
@@ -19,7 +19,11 @@ log = "0.4.17"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 version = "0.52.0"
-features = [ "Win32_Foundation", "Win32_System_Console" ]
+features = [
+    "Win32_Foundation",
+    "Win32_System_Console",
+    "Win32_System_Threading",
+]
 
 [dev-dependencies]
 insta = "1.6.0"

--- a/zellij-server/src/background_jobs.rs
+++ b/zellij-server/src/background_jobs.rs
@@ -386,7 +386,7 @@ fn write_session_state_to_disk(
 
 fn read_other_live_session_states(current_session_name: &str) -> BTreeMap<String, SessionInfo> {
     let mut other_session_names: Vec<String> = vec![];
-    let mut session_infos_on_machine = BTreeMap::new();
+    let session_infos_on_machine = BTreeMap::new();
     // we do this so that the session infos will be actual and we're
     // reasonably sure their session is running
     if let Ok(files) = fs::read_dir(&*ZELLIJ_SOCK_DIR) {

--- a/zellij-server/src/lib.rs
+++ b/zellij-server/src/lib.rs
@@ -25,7 +25,6 @@ use std::{
     thread,
 };
 use zellij_utils::envs;
-use zellij_utils::interprocess::local_socket::LocalSocketStream;
 #[cfg(unix)]
 use zellij_utils::nix::sys::stat::{umask, Mode};
 use zellij_utils::pane_size::Size;

--- a/zellij-server/src/os_input_output.rs
+++ b/zellij-server/src/os_input_output.rs
@@ -1,8 +1,7 @@
 use crate::{panes::PaneId, ClientId};
 
-use async_std::{fs::File as AsyncFile, io::ReadExt};
+use async_std::io::ReadExt;
 
-use interprocess::local_socket::LocalSocketStream;
 
 use std::ffi::OsString;
 use std::io::Error;
@@ -14,13 +13,11 @@ use zellij_utils::{
     data::Palette,
     errors::prelude::*,
     input::command::{RunCommand, TerminalAction},
-    interprocess,
     ipc::{
         ClientToServerMsg, ExitReason, IpcReceiverWithContext, IpcSenderWithContext,
         IpcSocketStream, ServerToClientMsg,
     },
     shared::default_palette,
-    signal_hook,
     tempfile::tempfile,
 };
 
@@ -102,7 +99,7 @@ fn handle_command_exit(mut child: Child) -> Result<Option<i32>> {
     };
 
     // returns the exit status, if any
-    let mut should_exit = false;
+    let should_exit = false;
     let mut attempts = 3;
     #[cfg(unix)]
     let mut signals =

--- a/zellij-server/src/plugins/plugin_loader.rs
+++ b/zellij-server/src/plugins/plugin_loader.rs
@@ -5,8 +5,6 @@ use crate::plugins::zellij_exports::{wasi_write_object, zellij_exports};
 use crate::plugins::PluginId;
 use highway::{HighwayHash, PortableHash};
 use log::info;
-use std::ffi::OsString;
-use std::path::Path;
 use std::{
     collections::{HashMap, HashSet},
     fs,

--- a/zellij-server/src/pty.rs
+++ b/zellij-server/src/pty.rs
@@ -1570,7 +1570,7 @@ impl Pty {
         // command
         // successfully opened
 
-        use sysinfo::PidExt;
+        
         let err_context = || format!("failed to apply run instruction");
         let quit_cb = Box::new({
             let senders = self.bus.senders.clone();

--- a/zellij-server/src/screen.rs
+++ b/zellij-server/src/screen.rs
@@ -3594,7 +3594,7 @@ pub(crate) fn screen_thread_main(
                     // update state
                     screen.session_name = name.clone();
                     screen.default_mode_info.session_name = Some(name.clone());
-                    for (_client_id, mut mode_info) in screen.mode_info.iter_mut() {
+                    for (_client_id, mode_info) in screen.mode_info.iter_mut() {
                         mode_info.session_name = Some(name.clone());
                     }
                     for (_, tab) in screen.tabs.iter_mut() {

--- a/zellij-server/src/tab/mod.rs
+++ b/zellij-server/src/tab/mod.rs
@@ -847,7 +847,7 @@ impl Tab {
     pub fn rename_session(&mut self, new_session_name: String) -> Result<()> {
         {
             let mode_infos = &mut self.mode_info.borrow_mut();
-            for (_client_id, mut mode_info) in mode_infos.iter_mut() {
+            for (_client_id, mode_info) in mode_infos.iter_mut() {
                 mode_info.session_name = Some(new_session_name.clone());
             }
             self.default_mode_info.session_name = Some(new_session_name);

--- a/zellij-utils/src/ipc.rs
+++ b/zellij-utils/src/ipc.rs
@@ -18,7 +18,6 @@ use crate::shared::set_permissions;
 
 #[cfg(unix)]
 use interprocess::local_socket::{LocalSocketListener, LocalSocketStream};
-use log::warn;
 
 #[cfg(unix)]
 use nix::unistd::dup;
@@ -408,8 +407,8 @@ where
                                 todo!("Decode first message and figure out what to do with the remainder")
                             }
                         },
-                        (rmp_serde::decode::Error::InvalidDataRead(io_error)
-                        | rmp_serde::decode::Error::InvalidMarkerRead(io_error))
+                        rmp_serde::decode::Error::InvalidDataRead(io_error)
+                        | rmp_serde::decode::Error::InvalidMarkerRead(io_error)
                             if io_error.kind() == std::io::ErrorKind::UnexpectedEof =>
                         {
                             counter += 1;
@@ -420,7 +419,7 @@ where
                             buf.reserve(1);
                             continue;
                         },
-                        e => {
+                        _e => {
                             return None;
                         },
                     }

--- a/zellij-utils/src/windows_utils/named_pipe.rs
+++ b/zellij-utils/src/windows_utils/named_pipe.rs
@@ -6,7 +6,7 @@ use std::{
     mem::MaybeUninit,
     os::windows::{
         ffi::OsStrExt,
-        io::{AsRawHandle, FromRawHandle, IntoRawHandle, OwnedHandle},
+        io::{AsRawHandle, FromRawHandle, OwnedHandle},
     },
     path::PathBuf,
     ptr,
@@ -60,7 +60,7 @@ struct EventedOverlapped(OVERLAPPED);
 
 impl Drop for EventedOverlapped {
     fn drop(&mut self) {
-        if (!self.0.hEvent.is_null()) {
+        if !self.0.hEvent.is_null() {
             unsafe {
                 CloseHandle(self.0.hEvent);
             }
@@ -158,7 +158,7 @@ impl Pipe {
         // the function returns a nonzero value. If the function
         // returns zero, GetLastError returns ERROR_PIPE_CONNECTED.
 
-        let mut pipe_handle = PipeStream::from(server_listener_pipe_handle);
+        let pipe_handle = PipeStream::from(server_listener_pipe_handle);
         let connected = if unsafe {
             ConnectNamedPipe(pipe_handle.0.as_raw_handle() as _, ptr::null_mut())
         } != 0


### PR DESCRIPTION
Windows StdIn or Output does not support Async Operations (except using `WaitForMultipleObjects` for a `select()` style approach).

The previous code used `mio` to check if there is new Input available, so I used the WinAPI Operations for that check.

I can not reproduce the issue on my development machine so I can not test this.